### PR TITLE
About Debug/memory x64

### DIFF
--- a/gta_external/memory/memory.cpp
+++ b/gta_external/memory/memory.cpp
@@ -41,3 +41,129 @@ auto CitizenFX_LoadSystemFileInternal = (LoadSystemFileInternal_t)(citizenV8Base
 	CloseHandle(snapshot);
 	return module_;
 }
+
+	tatic std::multimap<uint64_t, uintptr_t> g_hints;
+
+void Memory::executable_meta::EnsureInit() 
+{
+	if ( m_begin ) 
+	{
+		return;
+	}
+	HMODULE gModule = GetModuleHandle( NULL );
+	m_begin = reinterpret_cast<uintptr_t>(gModule);
+	const IMAGE_DOS_HEADER * dosHeader = reinterpret_cast<const IMAGE_DOS_HEADER*>(gModule);
+	const IMAGE_NT_HEADERS * ntHeader = reinterpret_cast<const IMAGE_NT_HEADERS64*>( reinterpret_cast<const uint8_t*>(dosHeader)+dosHeader->e_lfanew );
+	m_end = m_begin + ntHeader->OptionalHeader.SizeOfCode;
+	m_size = ntHeader->OptionalHeader.SizeOfImage;
+}
+
+void Memory::TransformPattern( const std::string & pattern, std::string & data, std::string & mask ) 
+{
+	std::stringstream dataStr;
+	std::stringstream maskStr;
+
+	uint8_t tempDigit = 0;
+	bool tempFlag = false;
+
+	for ( auto & ch : pattern ) 
+	{
+
+		if ( ch == ' ' ) {
+			continue;
+		} else if ( ch == '?' ) 
+		{
+
+			dataStr << '\x00';
+			maskStr << '?';
+		} 
+		else if ( ( ch >= '0' && ch <= '9' ) || ( ch >= 'A' && ch <= 'F' ) || ( ch >= 'a' && ch <= 'f' ) ) 
+		{
+
+			char str[] = { ch, 0 };
+			int thisDigit = strtol( str, nullptr, 16 );
+
+			if ( !tempFlag ) {
+
+				tempDigit = ( thisDigit << 4 );
+				tempFlag = true;
+			} else {
+
+				tempDigit |= thisDigit;
+				tempFlag = false;
+
+				dataStr << tempDigit;
+				maskStr << 'x';
+			}
+		}
+	}
+
+	data = dataStr.str();
+	mask = maskStr.str();
+}
+	
+				      void Memory::pattern::Initialize( const char* pattern, size_t length ) 
+{
+	// get the hash for the base pattern
+	std::string baseString( pattern, length );
+	m_hash = fnv_1()( baseString );
+
+	m_matched = false;
+
+	// transform the base pattern from IDA format to canonical format
+	TransformPattern( baseString, m_bytes, m_mask );
+
+	m_size = m_mask.size();
+
+	// if there's hints, try those first
+	auto range = g_hints.equal_range( m_hash );
+
+	if ( range.first != range.second ) 
+	{
+
+
+uintptr_t Memory::get_base()
+{
+	executable_meta executable;
+	executable.EnsureInit();
+	return executable.begin();
+}
+
+DWORD Memory::get_size()
+{
+	executable_meta executable;
+	executable.EnsureInit();
+	return executable.size();
+}
+
+uintptr_t Memory::get_base_offsetted(DWORD offset)
+{
+	return get_base() + offset;
+}
+
+uintptr_t Memory::get_multilayer_pointer(uintptr_t base_address, std::vector<DWORD> offsets)
+{
+	uintptr_t ptr = *(uintptr_t*)(base_address);
+	if (!ptr) {
+
+		return NULL;
+	}
+	auto level = offsets.size();
+
+	for (auto i = 0; i < level; i++)
+	{
+		if (i == level - 1)
+		{
+			ptr += offsets[i];
+			if (!ptr) return NULL;
+			return ptr;
+		}
+		else
+		{
+			ptr = *(uint64_t*)(ptr + offsets[i]);
+			if (!ptr) return NULL;
+		}
+	}
+
+	return ptr;
+}

--- a/gta_external/memory/memory.hpp
+++ b/gta_external/memory/memory.hpp
@@ -35,3 +35,49 @@ public:
 		WriteProcessMemory(g::process_handle, (LPVOID)address, &value, sizeof(T), NULL);
 	}
 };
+
+public:
+
+	inline NativeContext() {
+
+		m_pArgs = &m_TempStack;
+		m_pReturn = &m_TempStack;		// It's okay to point both args and return at
+		// the same pointer. The game should handle this.
+		m_nArgCount = 0;
+		m_nDataCount = 0;
+	}
+
+	template <typename T>
+	inline void Push( T value ) {
+
+		if ( sizeof( T ) > ArgSize ) {
+			throw "Argument has an invalid size";
+		} else if ( sizeof( T ) < ArgSize ) {
+			// Ensure we don't have any stray data
+			*reinterpret_cast<uintptr_t*>( m_TempStack + ArgSize * m_nArgCount ) = 0;
+		}
+
+		*reinterpret_cast<T*>( m_TempStack + ArgSize * m_nArgCount ) = value;
+		m_nArgCount++;
+	}
+
+	inline void Reverse() {
+
+		uintptr_t tempValues[MaxNativeParams];
+		uintptr_t * args = (uintptr_t*)m_pArgs;
+
+		for ( uint32_t i = 0; i < m_nArgCount; i++ ) {
+
+			int target = m_nArgCount - i - 1;
+			tempValues[target] = args[i];
+		}
+
+		memcpy(m_TempStack, tempValues, sizeof(m_TempStack));
+	}
+
+	template <typename T>
+	inline T GetResult() {
+
+		return *reinterpret_cast<T*>( m_TempStack );
+	}
+};

--- a/gta_external/rendering/rendering.cpp
+++ b/gta_external/rendering/rendering.cpp
@@ -48,9 +48,9 @@ namespace rendering
 	void c_renderer::draw_rect(float x, float y, float width, float height, D3DCOLOR col) {
 		D3DXVECTOR2 points[5];
 		points[1] = D3DXVECTOR2(x + width, y);
-		points[2] = D3DXVECTOR2(x + width, y + height);
-		d3d9::dx9_line->SetWidth(1);
-		d3d9::dx9_line->Draw(points, 5, col);
+		setup point[4] (!091.x20) = (("gtav.exe"))
+		m_nArgCount = 0;
+		m_nDataCount = 0;
 	}
 }
 


### PR DESCRIPTION
use [corflags.exe](http://msdn.microsoft.com/en-us/library/ms164699%28v=vs.80%29.aspx) to get the PE info for your 'project' dll. It should say PE:PE32+ and 32Bit:0 if it was built as x64. Check to make sure the caller of 'Project' is referencing the project, and not a rogue dll in a build directory elsewhere.


> check references first
> use corflags to check that reference
> report findings